### PR TITLE
Add prescriptive validation steps for confirming scan verdicts

### DIFF
--- a/rh_cve_checker/cli.py
+++ b/rh_cve_checker/cli.py
@@ -216,6 +216,12 @@ def main() -> None:
     envvar="OCP_VERSION",
     help="Specify OCP version directly (e.g., '4.16.46') instead of inspecting images"
 )
+@click.option(
+    "--validation-report",
+    type=click.Path(),
+    default=None,
+    help="Generate a standalone Markdown validation report at the specified path"
+)
 def analyze(
     files: tuple[str, ...],
     format: str,
@@ -236,6 +242,7 @@ def analyze(
     check_ocp_versions: bool,
     ocp_pull_secret: str | None,
     ocp_version: str | None,
+    validation_report: str | None,
 ) -> None:
     """
     Analyze scanner output files against Red Hat VEX data.
@@ -329,6 +336,16 @@ def analyze(
             _print_summary(report, verbose, show_all, limit, all_cvss_deltas, non_cve_only, filter_type, severity, severity_source)
         else:
             _print_summary(report, verbose, show_all, limit, all_cvss_deltas, non_cve_only, filter_type, severity, severity_source)
+
+        # Generate Markdown validation report if requested
+        if validation_report:
+            from .core.validation_report import generate_validation_report
+
+            md_content = generate_validation_report(report)
+            vr_path = Path(validation_report)
+            with open(vr_path, "w") as f:
+                f.write(md_content)
+            console.print(f"[green]Validation report saved to:[/green] {vr_path}")
             
     except ValueError as e:
         console.print(f"[red]Error:[/red] {e}")
@@ -908,6 +925,8 @@ def _print_summary(
                         console.print(f"     [dim]Fail if:[/dim]   {step.fail_condition}")
                     if step.context:
                         console.print(f"     [dim]Why:[/dim]       {step.context}")
+                    if step.reference:
+                        console.print(f"     [dim]Ref:[/dim]       {step.reference}")
                 console.print()
     
     # Recommendations

--- a/rh_cve_checker/cli.py
+++ b/rh_cve_checker/cli.py
@@ -850,9 +850,65 @@ def _print_summary(
         
         if len(findings_to_show) > display_limit:
             console.print(f"[dim]Showing first {display_limit} of {len(findings_to_show)} findings (use --limit 0 for all)[/dim]")
-        
+
         console.print(findings_table)
         console.print()
+
+        # Show validation steps for findings that have them, deduplicated
+        # by (CVE, package, verdict) so the same steps aren't repeated for
+        # every image/host that contains the same vulnerable package.
+        displayed = findings_to_show[:display_limit]
+        findings_with_steps = [r for r in displayed if r.validation_steps]
+        if findings_with_steps:
+            seen_keys: set[tuple[str, str, str]] = set()
+            deduped: list = []
+            extra_counts: dict[tuple[str, str, str], int] = {}
+            for result in findings_with_steps:
+                key = (
+                    result.finding.cve_id,
+                    result.finding.package_name or "",
+                    result.verdict.value,
+                )
+                if key not in seen_keys:
+                    seen_keys.add(key)
+                    deduped.append(result)
+                    extra_counts[key] = 0
+                else:
+                    extra_counts[key] += 1
+
+            console.print(Panel.fit(
+                "[bold]Validation Steps — Confirm These Results On Your System[/bold]",
+                border_style="yellow",
+            ))
+            console.print()
+            for result in deduped:
+                cve_label = result.finding.cve_id
+                pkg_label = result.finding.package_name or ""
+                verdict_label = result.verdict.value.replace("_", " ").title()
+                key = (cve_label, pkg_label, result.verdict.value)
+                extras = extra_counts.get(key, 0)
+
+                header = (
+                    f"[bold cyan]{cve_label}[/bold cyan]"
+                    + (f" [dim]({pkg_label})[/dim]" if pkg_label else "")
+                    + f" — [bold]{verdict_label}[/bold]"
+                )
+                if extras > 0:
+                    occurrence_word = "occurrence" if extras == 1 else "occurrences"
+                    header += f" [dim](+{extras} additional {occurrence_word})[/dim]"
+                console.print(header)
+
+                for i, step in enumerate(result.validation_steps, 1):
+                    console.print(f"  [bold]{i}. {step.title}[/bold]")
+                    if step.command:
+                        console.print(f"     [green]$ {step.command}[/green]")
+                    if step.expected:
+                        console.print(f"     [dim]Expected:[/dim]  {step.expected}")
+                    if step.fail_condition:
+                        console.print(f"     [dim]Fail if:[/dim]   {step.fail_condition}")
+                    if step.context:
+                        console.print(f"     [dim]Why:[/dim]       {step.context}")
+                console.print()
     
     # Recommendations
     if interpretation['recommendations']:

--- a/rh_cve_checker/core/__init__.py
+++ b/rh_cve_checker/core/__init__.py
@@ -13,6 +13,7 @@ from .models import (
     Severity,
     SeverityFixMetrics,
     SeverityMetrics,
+    ValidationStep,
     Verdict,
 )
 from .analyzer import CVEAnalyzer
@@ -32,6 +33,7 @@ __all__ = [
     "Severity",
     "SeverityFixMetrics",
     "SeverityMetrics",
+    "ValidationStep",
     "Verdict",
     "CVEAnalyzer",
     "ValidationScorer",

--- a/rh_cve_checker/core/analyzer.py
+++ b/rh_cve_checker/core/analyzer.py
@@ -630,7 +630,18 @@ class CVEAnalyzer:
             rh_probability=rh_probability,
             flags=flags,
             remediation=remediation,
+            vex_fixed_version=vex_fixed_version,
         )
+
+        # Build VEX provenance fields
+        vex_document_url = None
+        vex_retrieved_at = None
+        if vex_data:
+            try:
+                vex_document_url = self.vex_client._get_vex_url(finding.cve_id)
+            except (ValueError, AttributeError):
+                pass
+            vex_retrieved_at = vex_data.retrieved_at
 
         return AnalysisResult(
             finding=finding,
@@ -645,6 +656,8 @@ class CVEAnalyzer:
             flags=flags,
             remediation=remediation,
             validation_steps=validation_steps,
+            vex_document_url=vex_document_url,
+            vex_retrieved_at=vex_retrieved_at,
         )
     
     def _enrich_with_ocp_data(self, results: list[AnalysisResult]) -> None:
@@ -933,6 +946,7 @@ class CVEAnalyzer:
         rh_probability: float,
         flags: list[str],
         remediation: "Remediation | None",
+        vex_fixed_version: str | None = None,
     ) -> list[ValidationStep]:
         """
         Generate prescriptive validation steps based on the verdict and evidence.
@@ -945,6 +959,7 @@ class CVEAnalyzer:
         pkg = finding.package_name
         pkg_ver = finding.package_version
         cve = finding.cve_id
+        cve_page_url = f"https://access.redhat.com/security/cve/{cve}"
         # Use image_name directly if it already contains a registry prefix,
         # otherwise use full_image_reference which prepends the registry.
         image_name = finding.image_name or ""
@@ -952,6 +967,14 @@ class CVEAnalyzer:
             image = finding.full_image_reference
         else:
             image = image_name or None
+
+        # Build VEX document URL for reference fields
+        vex_url = None
+        if vex_data:
+            try:
+                vex_url = self.vex_client._get_vex_url(cve)
+            except (ValueError, AttributeError):
+                pass
 
         # -----------------------------------------------------------
         # 1. Steps specific to false-positive verdicts
@@ -962,13 +985,23 @@ class CVEAnalyzer:
             has_not_affected_flag = any("[FP: NOT AFFECTED]" in f for f in flags)
 
             if has_patched_flag and pkg:
+                fixed_ver_display = (
+                    f"Version should be >= {vex_fixed_version}. "
+                    f"Installed: {pkg_ver}"
+                    if vex_fixed_version and pkg_ver
+                    else (
+                        f"Version should be >= {vex_fixed_version}."
+                        if vex_fixed_version
+                        else (
+                            f"Version should be >= the VEX fixed version. "
+                            f"Installed: {pkg_ver}" if pkg_ver else "Version output from rpm"
+                        )
+                    )
+                )
                 steps.append(ValidationStep(
                     title="Verify installed package version",
                     command=f"rpm -q {pkg}",
-                    expected=(
-                        f"Version should be >= the VEX fixed version. "
-                        f"Installed: {pkg_ver}" if pkg_ver else "Version output from rpm"
-                    ),
+                    expected=fixed_ver_display,
                     fail_condition=(
                         "Package is not installed, or version is older than the "
                         "VEX fixed version — the finding may be a true positive."
@@ -977,6 +1010,7 @@ class CVEAnalyzer:
                         "This finding was classified as a false positive because the "
                         "installed RPM version appears to already include the fix."
                     ),
+                    reference=cve_page_url,
                 ))
                 # Suggest verifying the fix via errata
                 if remediation and remediation.rhsa_id:
@@ -992,6 +1026,7 @@ class CVEAnalyzer:
                             "Checking the RPM changelog confirms the fix was back-ported "
                             "via the official Red Hat errata, not just a version bump."
                         ),
+                        reference=remediation.rhsa_url,
                     ))
 
             if has_not_affected_flag:
@@ -1014,6 +1049,7 @@ class CVEAnalyzer:
                         "The VEX data declares this product not vulnerable, but that "
                         "only holds if your image actually is that product."
                     ),
+                    reference=vex_url,
                 ))
 
         # -----------------------------------------------------------
@@ -1071,6 +1107,7 @@ class CVEAnalyzer:
                         "official OCP components mirrored to quay, but not always. "
                         "Checking the release payload is definitive."
                     ),
+                    reference=cve_page_url,
                 ))
                 steps.append(ValidationStep(
                     title="Check the image's Red Hat build labels",
@@ -1126,6 +1163,7 @@ class CVEAnalyzer:
                         f"registry alone is not conclusive. The image labels are the "
                         f"definitive indicator."
                     ),
+                    reference=cve_page_url,
                 ))
                 if has_el_suffix and pkg:
                     steps.append(ValidationStep(
@@ -1218,7 +1256,33 @@ class CVEAnalyzer:
                         f"probability is {rh_probability:.0%}. Most Docker Hub "
                         f"images are not built or supported by Red Hat."
                     ),
+                    reference=cve_page_url,
                 ))
+                if has_el_suffix and pkg:
+                    steps.append(ValidationStep(
+                        title="Verify the RPM is signed by Red Hat",
+                        command=(
+                            f"podman run --rm --entrypoint rpm {image} "
+                            f"-qi {pkg} 2>/dev/null | "
+                            f"grep -E 'Vendor|Signature'"
+                        ),
+                        expected=(
+                            "Vendor: 'Red Hat, Inc.' and Signature references "
+                            "Red Hat's GPG key (fd431d51 or d4082792). This confirms "
+                            "the package is a genuine Red Hat RPM, not a rebuild."
+                        ),
+                        fail_condition=(
+                            "Different vendor, unsigned, or non-Red Hat GPG key — "
+                            "the RPM may be from CentOS, AlmaLinux, Rocky Linux, or "
+                            "another RHEL rebuild. VEX data may still be directionally "
+                            "useful but is not authoritative."
+                        ),
+                        context=(
+                            f"Package '{pkg}' version '{pkg_ver}' has a .el suffix "
+                            f"suggesting RHEL origin, but the image is on Docker Hub. "
+                            f"Checking the RPM signature confirms provenance."
+                        ),
+                    ))
 
             # --- Host-based or no image context ---
             elif not image and pkg:
@@ -1269,7 +1333,7 @@ class CVEAnalyzer:
                 steps.append(ValidationStep(
                     title="Cross-reference Red Hat's CVE page",
                     command=None,
-                    expected=f"Review https://access.redhat.com/security/cve/{cve}",
+                    expected=f"Review {cve_page_url}",
                     fail_condition=(
                         "If Red Hat lists your product/version as affected, "
                         "this may not be a false positive."
@@ -1277,6 +1341,25 @@ class CVEAnalyzer:
                     context=(
                         "Red Hat's CVE page provides the definitive affected-product "
                         "list. Check whether your specific product and version appear."
+                    ),
+                    reference=cve_page_url,
+                ))
+
+            # Container layer guidance for likely FP container findings
+            if image and pkg:
+                steps.append(ValidationStep(
+                    title="Identify which image layer introduced the package",
+                    command=f"podman history {image} --no-trunc",
+                    expected=(
+                        "Identify the layer that installed the package. If it comes "
+                        "from the base image, the platform team owns remediation. "
+                        "If from an application layer, the app team owns it."
+                    ),
+                    fail_condition="N/A",
+                    context=(
+                        "Understanding which layer introduced a package helps "
+                        "determine the correct remediation owner (platform team "
+                        "vs. application team)."
                     ),
                 ))
 
@@ -1363,6 +1446,194 @@ class CVEAnalyzer:
                     "The VEX document was not found, but the older Security Data API "
                     "may still have information for this CVE."
                 ),
+                reference=cve_page_url,
+            ))
+
+        # -----------------------------------------------------------
+        # 5b. Steps for INCONCLUSIVE verdicts
+        # -----------------------------------------------------------
+        if verdict == Verdict.INCONCLUSIVE:
+            # Only add the manual CVE check if not already added by no-VEX section
+            if not has_no_vex_flag:
+                steps.append(ValidationStep(
+                    title="Manually check Red Hat's CVE database",
+                    command=(
+                        f"curl -s https://access.redhat.com/hydra/rest/securitydata/cve/{cve}.json "
+                        f"| python3 -m json.tool | head -20"
+                    ),
+                    expected=(
+                        "JSON response with threat_severity, public_date, and "
+                        "affected_release fields — confirms Red Hat has tracked this CVE."
+                    ),
+                    fail_condition=(
+                        "404 or empty response — Red Hat may not have published data "
+                        "for this CVE yet. It may be too new, or not applicable to "
+                        "RH products."
+                    ),
+                    context=(
+                        "An inconclusive verdict means there was not enough data to "
+                        "determine a definitive result. Checking the Security Data "
+                        "API may provide additional context."
+                    ),
+                    reference=cve_page_url,
+                ))
+
+            if pkg:
+                steps.append(ValidationStep(
+                    title="Verify package origin",
+                    command=f"rpm -qi {pkg} 2>/dev/null | grep -E 'Vendor|Signature'",
+                    expected=(
+                        "Vendor: 'Red Hat, Inc.' — confirms the package is from "
+                        "Red Hat. If not, the finding may be NOT_APPLICABLE rather "
+                        "than inconclusive."
+                    ),
+                    fail_condition=(
+                        "Different vendor or unsigned — the software may be from a "
+                        "third-party source. Consider re-classifying as not applicable."
+                    ),
+                    context=(
+                        "Determining whether the package is genuinely from Red Hat "
+                        "helps decide the correct remediation path."
+                    ),
+                ))
+
+            steps.append(ValidationStep(
+                title="Check for consolidated or alternate CVE IDs",
+                command=None,
+                expected=(
+                    f"Search {cve_page_url} for references to "
+                    f"other CVE IDs. This CVE may have been consolidated with "
+                    f"another ID or may be tracked under a different identifier."
+                ),
+                fail_condition="N/A",
+                context=(
+                    "Some CVEs are duplicates or aliases. If Red Hat tracks this "
+                    "vulnerability under a different ID, the VEX data may exist "
+                    "under that alternate ID."
+                ),
+                reference=cve_page_url,
+            ))
+
+            steps.append(ValidationStep(
+                title="Document finding for manual review",
+                command=None,
+                expected=(
+                    f"Record the following for manual review:\n"
+                    f"  - CVE: {cve}\n"
+                    f"  - Package: {pkg or 'N/A'}\n"
+                    f"  - Version: {pkg_ver or 'N/A'}\n"
+                    f"  - Context: {image or finding.host or 'N/A'}\n"
+                    f"  - Reason: Inconclusive — insufficient data for automated determination"
+                ),
+                fail_condition="N/A",
+                context=(
+                    "When automated analysis is inconclusive, document the finding "
+                    "for manual review by your security team."
+                ),
+            ))
+
+        # -----------------------------------------------------------
+        # 5c. Steps for Will Not Fix findings
+        # -----------------------------------------------------------
+        has_wnf_flag = any("[WILL NOT FIX]" in f for f in flags)
+        if has_wnf_flag:
+            if image:
+                steps.append(ValidationStep(
+                    title="Confirm the Will Not Fix determination applies to your product",
+                    command=(
+                        f"podman inspect {image} 2>/dev/null | "
+                        f"jq '.[].Config.Labels[\"com.redhat.component\"]'"
+                    ),
+                    expected=(
+                        "The component label should match the product listed in "
+                        "Red Hat's Will Not Fix determination. If it matches, the "
+                        "WNF status applies to your deployment."
+                    ),
+                    fail_condition=(
+                        "Component label does not match the WNF product — the "
+                        "determination may not apply to your specific image/product."
+                    ),
+                    context=(
+                        "Red Hat's Will Not Fix decisions are product-specific. "
+                        "Verify that your image corresponds to the product for which "
+                        "the WNF decision was made."
+                    ),
+                    reference=cve_page_url,
+                ))
+            elif pkg:
+                steps.append(ValidationStep(
+                    title="Confirm the Will Not Fix determination applies to your product",
+                    command=f"rpm -qi {pkg} 2>/dev/null | grep -E 'Vendor|Name|Release'",
+                    expected=(
+                        "The RPM name and release should match the product listed "
+                        "in Red Hat's Will Not Fix determination."
+                    ),
+                    fail_condition=(
+                        "Package metadata does not match the WNF product — "
+                        "the determination may not apply to your environment."
+                    ),
+                    context=(
+                        "Red Hat's Will Not Fix decisions are product-specific. "
+                        "Verify that your package corresponds to the product for "
+                        "which the WNF decision was made."
+                    ),
+                    reference=cve_page_url,
+                ))
+
+            steps.append(ValidationStep(
+                title="Review Red Hat's rationale for not fixing",
+                command=None,
+                expected=(
+                    f"Visit {cve_page_url} and check the "
+                    f"'Statement' section for Red Hat's rationale. Common reasons "
+                    f"include low exploitability, product EOL, or architectural "
+                    f"constraints that prevent a fix."
+                ),
+                fail_condition="N/A",
+                context=(
+                    "Understanding why Red Hat decided not to fix helps inform "
+                    "your risk acceptance decision and any compensating controls."
+                ),
+                reference=cve_page_url,
+            ))
+
+            steps.append(ValidationStep(
+                title="Evaluate compensating controls or workarounds",
+                command=None,
+                expected=(
+                    f"Check the 'Mitigation' section on {cve_page_url} "
+                    f"for any workarounds Red Hat recommends. Common mitigations "
+                    f"include configuration changes, network restrictions, or "
+                    f"SELinux policies."
+                ),
+                fail_condition="N/A",
+                context=(
+                    "Even when a fix is not planned, Red Hat often provides "
+                    "mitigation guidance that can reduce the vulnerability's "
+                    "impact."
+                ),
+                reference=cve_page_url,
+            ))
+
+            steps.append(ValidationStep(
+                title="Document risk acceptance for audit trail",
+                command=None,
+                expected=(
+                    f"Record the following for risk acceptance:\n"
+                    f"  - CVE: {cve}\n"
+                    f"  - Product/Package: {pkg or 'N/A'}\n"
+                    f"  - Red Hat Status: Will Not Fix\n"
+                    f"  - Rationale: [from CVE page Statement section]\n"
+                    f"  - Compensating Controls: [from Mitigation section]\n"
+                    f"  - Risk Accepted By: [name and date]\n"
+                    f"  - Review Date: [next review date]"
+                ),
+                fail_condition="N/A",
+                context=(
+                    "Will Not Fix findings require explicit risk acceptance. "
+                    "Document the decision, rationale, any compensating controls, "
+                    "and schedule a periodic review."
+                ),
             ))
 
         # -----------------------------------------------------------
@@ -1373,7 +1644,7 @@ class CVEAnalyzer:
                 title="Verify Red Hat's severity for your specific product",
                 command=None,
                 expected=(
-                    f"Review https://access.redhat.com/security/cve/{cve} and check "
+                    f"Review {cve_page_url} and check "
                     "the per-product severity table. Red Hat may rate severity "
                     "differently per product depending on exposure."
                 ),
@@ -1386,6 +1657,7 @@ class CVEAnalyzer:
                     "differ from the scanner's rating. The per-product table on the "
                     "CVE page is the authoritative source."
                 ),
+                reference=cve_page_url,
             ))
             if remediation and remediation.rhsa_id:
                 steps.append(ValidationStep(
@@ -1403,6 +1675,7 @@ class CVEAnalyzer:
                         "Red Hat software — they evaluate exploitability in the "
                         "context of their specific builds and configurations."
                     ),
+                    reference=remediation.rhsa_url,
                 ))
 
         # -----------------------------------------------------------
@@ -1425,13 +1698,14 @@ class CVEAnalyzer:
                         f"Red Hat has published {remediation.rhsa_id} with a fix. "
                         "Applying it resolves this finding."
                     ),
+                    reference=remediation.rhsa_url,
                 ))
             elif not remediation and vex_data:
                 steps.append(ValidationStep(
                     title="Check for available fixes",
                     command=None,
                     expected=(
-                        f"Visit https://access.redhat.com/security/cve/{cve} and "
+                        f"Visit {cve_page_url} and "
                         "check the 'Affected Packages and Issued Red Hat Security "
                         "Errata' section for your product."
                     ),
@@ -1442,6 +1716,25 @@ class CVEAnalyzer:
                     context=(
                         "No matching RHSA was found for your specific package/version "
                         "combination, but one may exist for a different product stream."
+                    ),
+                    reference=cve_page_url,
+                ))
+
+            # Container layer guidance for true positive container findings
+            if image and pkg:
+                steps.append(ValidationStep(
+                    title="Identify which image layer introduced the package",
+                    command=f"podman history {image} --no-trunc",
+                    expected=(
+                        "Identify the layer that installed the package. If it comes "
+                        "from the base image, the platform team owns remediation. "
+                        "If from an application layer, the app team owns it."
+                    ),
+                    fail_condition="N/A",
+                    context=(
+                        "Understanding which layer introduced a package helps "
+                        "determine the correct remediation owner (platform team "
+                        "vs. application team)."
                     ),
                 ))
 

--- a/rh_cve_checker/core/analyzer.py
+++ b/rh_cve_checker/core/analyzer.py
@@ -15,6 +15,7 @@ from .models import (
     Severity,
     SeverityFixMetrics,
     SeverityMetrics,
+    ValidationStep,
     Verdict,
 )
 from .registry_detector import RegistryDetector
@@ -423,8 +424,12 @@ class CVEAnalyzer:
             elif finding.related_cves:
                 # Has related CVE but no VEX data found for it
                 flags.append(f"[via {finding.vuln_id}] Related CVE: {finding.related_cves[0]} (no VEX data)")
-                
+
                 verdict = self._determine_verdict_no_vex(finding, rh_probability)
+                validation_steps = self._generate_validation_steps(
+                    finding=finding, vex_data=None, verdict=verdict,
+                    rh_probability=rh_probability, flags=flags, remediation=None,
+                )
                 return AnalysisResult(
                     finding=finding,
                     vex_data=None,
@@ -436,6 +441,7 @@ class CVEAnalyzer:
                     verdict=verdict,
                     flags=flags,
                     notes=f"Reported as {finding.vuln_id_type} ({finding.vuln_id}), related to {finding.related_cves[0]}.",
+                    validation_steps=validation_steps,
                 )
             else:
                 # No related CVE - truly cannot validate
@@ -458,7 +464,11 @@ class CVEAnalyzer:
         if not vex_data:
             verdict = self._determine_verdict_no_vex(finding, rh_probability)
             flags.append("[!] No RH VEX data found")
-            
+
+            validation_steps = self._generate_validation_steps(
+                finding=finding, vex_data=None, verdict=verdict,
+                rh_probability=rh_probability, flags=flags, remediation=None,
+            )
             return AnalysisResult(
                 finding=finding,
                 vex_data=None,
@@ -469,6 +479,7 @@ class CVEAnalyzer:
                 rh_source_probability=rh_probability,
                 verdict=verdict,
                 flags=flags,
+                validation_steps=validation_steps,
             )
         
         # Get per-product severity if available, otherwise use global
@@ -611,6 +622,16 @@ class CVEAnalyzer:
             rh_probability=rh_probability,
         )
         
+        # Generate prescriptive validation steps
+        validation_steps = self._generate_validation_steps(
+            finding=finding,
+            vex_data=vex_data,
+            verdict=verdict,
+            rh_probability=rh_probability,
+            flags=flags,
+            remediation=remediation,
+        )
+
         return AnalysisResult(
             finding=finding,
             vex_data=vex_data,
@@ -623,6 +644,7 @@ class CVEAnalyzer:
             verdict=verdict,
             flags=flags,
             remediation=remediation,
+            validation_steps=validation_steps,
         )
     
     def _enrich_with_ocp_data(self, results: list[AnalysisResult]) -> None:
@@ -902,7 +924,529 @@ class CVEAnalyzer:
                 f"Found {len(multi_component_cves)} CVE+package combinations "
                 f"affecting multiple OCP components"
             )
-    
+
+    def _generate_validation_steps(
+        self,
+        finding: ScannerFinding,
+        vex_data: RedHatVEXData | None,
+        verdict: Verdict,
+        rh_probability: float,
+        flags: list[str],
+        remediation: "Remediation | None",
+    ) -> list[ValidationStep]:
+        """
+        Generate prescriptive validation steps based on the verdict and evidence.
+
+        These steps tell the user exactly what to check on their system to
+        confirm or refute the tool's conclusion.
+        """
+        steps: list[ValidationStep] = []
+
+        pkg = finding.package_name
+        pkg_ver = finding.package_version
+        cve = finding.cve_id
+        # Use image_name directly if it already contains a registry prefix,
+        # otherwise use full_image_reference which prepends the registry.
+        image_name = finding.image_name or ""
+        if finding.registry and image_name and not image_name.startswith(finding.registry):
+            image = finding.full_image_reference
+        else:
+            image = image_name or None
+
+        # -----------------------------------------------------------
+        # 1. Steps specific to false-positive verdicts
+        # -----------------------------------------------------------
+        if verdict == Verdict.FALSE_POSITIVE:
+            # Determine which FP reason triggered
+            has_patched_flag = any("[FP: PATCHED]" in f for f in flags)
+            has_not_affected_flag = any("[FP: NOT AFFECTED]" in f for f in flags)
+
+            if has_patched_flag and pkg:
+                steps.append(ValidationStep(
+                    title="Verify installed package version",
+                    command=f"rpm -q {pkg}",
+                    expected=(
+                        f"Version should be >= the VEX fixed version. "
+                        f"Installed: {pkg_ver}" if pkg_ver else "Version output from rpm"
+                    ),
+                    fail_condition=(
+                        "Package is not installed, or version is older than the "
+                        "VEX fixed version — the finding may be a true positive."
+                    ),
+                    context=(
+                        "This finding was classified as a false positive because the "
+                        "installed RPM version appears to already include the fix."
+                    ),
+                ))
+                # Suggest verifying the fix via errata
+                if remediation and remediation.rhsa_id:
+                    steps.append(ValidationStep(
+                        title="Confirm the RHSA errata was applied",
+                        command=f"rpm -q --changelog {pkg} | grep -i {remediation.rhsa_id}",
+                        expected=f"Changelog entry referencing {remediation.rhsa_id}.",
+                        fail_condition=(
+                            "No changelog match — the version number may coincide but "
+                            "the Red Hat errata was never applied. Investigate further."
+                        ),
+                        context=(
+                            "Checking the RPM changelog confirms the fix was back-ported "
+                            "via the official Red Hat errata, not just a version bump."
+                        ),
+                    ))
+
+            if has_not_affected_flag:
+                steps.append(ValidationStep(
+                    title="Confirm target product matches VEX not-affected entry",
+                    command=(
+                        f"podman inspect {image} | jq '.[].Config.Labels'"
+                        if image else None
+                    ),
+                    expected=(
+                        "Labels should identify the image as the Red Hat product "
+                        "listed in the VEX not-affected entry (e.g., "
+                        "'com.redhat.component', 'name', 'release')."
+                    ),
+                    fail_condition=(
+                        "Image labels do not match the VEX product — the not-affected "
+                        "determination may not apply to this specific build."
+                    ),
+                    context=(
+                        "The VEX data declares this product not vulnerable, but that "
+                        "only holds if your image actually is that product."
+                    ),
+                ))
+
+        # -----------------------------------------------------------
+        # 2. Steps for likely-false-positive verdicts
+        # -----------------------------------------------------------
+        if verdict == Verdict.LIKELY_FALSE_POSITIVE:
+            registry = finding.registry or ""
+            # Extract registry from image name if not set explicitly
+            if not registry and image:
+                extracted = self.registry_detector._extract_registry_from_image(image)
+                if extracted:
+                    registry = extracted
+            registry_lower = registry.lower()
+            image_lower = (image or "").lower()
+
+            # Detect specific contexts from registry and image name
+            is_quay = "quay.io" in registry_lower
+            is_openshift_image = any(
+                kw in image_lower
+                for kw in ("openshift", "ocp-v4", "ocp-release", "ose-")
+            )
+            is_docker_hub = any(
+                x in registry_lower for x in ("docker.io", "index.docker.io")
+            )
+            is_known_non_rh = any(
+                x in registry_lower
+                for x in ("gcr.io", "ghcr.io", "mcr.microsoft.com", ".ecr.")
+            )
+            has_el_suffix = bool(
+                pkg_ver and re.search(r"\.el\d+", pkg_ver)
+            ) if pkg_ver else False
+
+            # --- OpenShift image on quay.io ---
+            if is_openshift_image and is_quay and image:
+                steps.append(ValidationStep(
+                    title="Verify this is an official OpenShift release image",
+                    command=(
+                        f"oc adm release info "
+                        f"$(oc get clusterversion version -o "
+                        f"jsonpath='{{.status.desired.image}}') "
+                        f"--pullspecs 2>/dev/null | grep -i "
+                        f"{image.split('/')[-1].split('@')[0].split(':')[0]}"
+                    ),
+                    expected=(
+                        "Image appears in the release payload — it is an official "
+                        "OpenShift component and Red Hat VEX data applies."
+                    ),
+                    fail_condition=(
+                        "Image not found in the release payload — it may be a custom "
+                        "or third-party operator image using an OpenShift-like naming "
+                        "convention. Investigate its actual origin."
+                    ),
+                    context=(
+                        "Images on quay.io with 'openshift' in the path are often "
+                        "official OCP components mirrored to quay, but not always. "
+                        "Checking the release payload is definitive."
+                    ),
+                ))
+                steps.append(ValidationStep(
+                    title="Check the image's Red Hat build labels",
+                    command=(
+                        f"oc image info {image} "
+                        f"--filter-by-os linux/amd64 -o json 2>/dev/null | "
+                        f"jq '.config.config.Labels | "
+                        f"{{component: .\"com.redhat.component\", "
+                        f"name: .name, build_host: .\"com.redhat.build-host\"}}'"
+                    ),
+                    expected=(
+                        "'com.redhat.component' is set and 'com.redhat.build-host' "
+                        "references a Red Hat build system (*.redhat.com). This "
+                        "confirms the image was built by Red Hat."
+                    ),
+                    fail_condition=(
+                        "Labels are missing or build-host is not a Red Hat system — "
+                        "the image may be a community or third-party build."
+                    ),
+                    context=(
+                        "Red Hat-built images embed build metadata in OCI labels. "
+                        "These labels are difficult to forge and are a reliable "
+                        "indicator of provenance."
+                    ),
+                ))
+
+            # --- Generic quay.io image (not obviously OpenShift) ---
+            elif is_quay and image:
+                steps.append(ValidationStep(
+                    title="Check if this image is built from a Red Hat base",
+                    command=(
+                        f"podman inspect {image} 2>/dev/null | "
+                        f"jq '.[].Config.Labels | "
+                        f"{{component: .\"com.redhat.component\", "
+                        f"vendor: .vendor, "
+                        f"name: .name, "
+                        f"build_host: .\"com.redhat.build-host\"}}'"
+                    ),
+                    expected=(
+                        "'vendor' is 'Red Hat, Inc.' and 'com.redhat.component' is "
+                        "set — the image is a Red Hat product even though it is "
+                        "hosted on quay.io."
+                    ),
+                    fail_condition=(
+                        "Labels show a different vendor or are missing — the image "
+                        "is likely not a Red Hat product. Red Hat VEX data does not "
+                        "apply and the scanner finding should be evaluated against "
+                        "the upstream project's advisories instead."
+                    ),
+                    context=(
+                        f"quay.io hosts both Red Hat and third-party content. "
+                        f"RH source probability is {rh_probability:.0%} because the "
+                        f"registry alone is not conclusive. The image labels are the "
+                        f"definitive indicator."
+                    ),
+                ))
+                if has_el_suffix and pkg:
+                    steps.append(ValidationStep(
+                        title="Verify the RPM is signed by Red Hat",
+                        command=(
+                            f"podman run --rm --entrypoint rpm {image} "
+                            f"-qi {pkg} 2>/dev/null | "
+                            f"grep -E 'Vendor|Signature'"
+                        ),
+                        expected=(
+                            "Vendor: 'Red Hat, Inc.' and Signature references "
+                            "Red Hat's GPG key (fd431d51 or d4082792). This confirms "
+                            "the package is a genuine Red Hat RPM, not a rebuild."
+                        ),
+                        fail_condition=(
+                            "Different vendor, unsigned, or non-Red Hat GPG key — "
+                            "the RPM may be from CentOS, AlmaLinux, Rocky Linux, or "
+                            "another RHEL rebuild. VEX data may still be directionally "
+                            "useful but is not authoritative."
+                        ),
+                        context=(
+                            f"Package '{pkg}' version '{pkg_ver}' has a .el suffix "
+                            f"suggesting RHEL origin, but the image is on quay.io. "
+                            f"Checking the RPM signature confirms provenance."
+                        ),
+                    ))
+
+            # --- Known non-Red Hat registries ---
+            elif is_known_non_rh and image:
+                reg_info = self.registry_detector.get_registry_info(registry)
+                reg_desc = reg_info.get("description", registry)
+                steps.append(ValidationStep(
+                    title=f"Image is from {reg_desc} — likely not Red Hat software",
+                    command=None,
+                    expected=(
+                        f"This image is hosted on {registry} which is not a Red Hat "
+                        f"registry. Unless the image is a verified mirror of a "
+                        f"Red Hat product, the CVE finding should be evaluated "
+                        f"against the upstream project, not Red Hat's VEX data."
+                    ),
+                    fail_condition=(
+                        "If the image IS a mirror of a Red Hat product (e.g., a "
+                        "copy of a UBI image pushed to an internal registry), "
+                        "re-check using the original registry.redhat.io reference."
+                    ),
+                    context=(
+                        f"RH source probability is {rh_probability:.0%}. "
+                        f"{reg_desc} does not host Red Hat-built images."
+                    ),
+                ))
+                if pkg:
+                    steps.append(ValidationStep(
+                        title="Check the upstream project for this CVE",
+                        command=None,
+                        expected=(
+                            f"Search the upstream project's security advisories or "
+                            f"GitHub security tab for {cve}. Remediation should "
+                            f"follow the upstream project's guidance (upgrade the "
+                            f"dependency, rebuild the image, etc.)."
+                        ),
+                        fail_condition="N/A",
+                        context=(
+                            f"Since '{pkg}' is in a non-Red Hat image, RHSA errata "
+                            f"do not apply. The upstream project's fix is the correct "
+                            f"remediation path."
+                        ),
+                    ))
+
+            # --- Docker Hub images ---
+            elif is_docker_hub and image:
+                steps.append(ValidationStep(
+                    title="Verify this Docker Hub image is not a Red Hat product",
+                    command=(
+                        f"podman inspect {image} 2>/dev/null | "
+                        f"jq '.[].Config.Labels | "
+                        f"{{vendor: .vendor, "
+                        f"component: .\"com.redhat.component\"}}'"
+                    ),
+                    expected=(
+                        "Vendor is not 'Red Hat, Inc.' — the image is a community "
+                        "or third-party image from Docker Hub."
+                    ),
+                    fail_condition=(
+                        "Vendor IS 'Red Hat, Inc.' — some Red Hat images are mirrored "
+                        "to Docker Hub. If confirmed, re-evaluate with registry.redhat.io "
+                        "as the source."
+                    ),
+                    context=(
+                        f"Docker Hub hosts primarily community images. RH source "
+                        f"probability is {rh_probability:.0%}. Most Docker Hub "
+                        f"images are not built or supported by Red Hat."
+                    ),
+                ))
+
+            # --- Host-based or no image context ---
+            elif not image and pkg:
+                steps.append(ValidationStep(
+                    title="Verify the RPM vendor on the target host",
+                    command=f"rpm -qi {pkg} 2>/dev/null | grep -E 'Vendor|Signature'",
+                    expected=(
+                        "Vendor: 'Red Hat, Inc.' and Signature references Red Hat's "
+                        "GPG key. This confirms the package is from Red Hat."
+                    ),
+                    fail_condition=(
+                        "Different vendor or unsigned — the package may be from a "
+                        "third-party repository, EPEL, or a RHEL rebuild (CentOS, "
+                        "AlmaLinux, Rocky Linux). VEX data may not be authoritative."
+                    ),
+                    context=(
+                        f"RH source probability is {rh_probability:.0%}. Checking "
+                        f"the RPM metadata on the actual host is the most reliable "
+                        f"way to confirm software origin."
+                    ),
+                ))
+
+            # --- Fallback for unrecognized contexts ---
+            else:
+                steps.append(ValidationStep(
+                    title="Verify the software origin",
+                    command=(
+                        f"rpm -qi {pkg} 2>/dev/null | grep -E 'Vendor|Packager'"
+                        if pkg else None
+                    ),
+                    expected=(
+                        "Vendor should be 'Red Hat, Inc.' if this is genuine "
+                        "Red Hat-packaged software."
+                    ),
+                    fail_condition=(
+                        "Different vendor or 'package not installed' — the scanner "
+                        "may be reporting on upstream/third-party software."
+                    ),
+                    context=(
+                        f"RH source probability is {rh_probability:.0%}. If this "
+                        "software is not from Red Hat, the CVE may still apply via "
+                        "the upstream project but Red Hat's VEX data would not be "
+                        "authoritative."
+                    ),
+                ))
+
+            if vex_data:
+                steps.append(ValidationStep(
+                    title="Cross-reference Red Hat's CVE page",
+                    command=None,
+                    expected=f"Review https://access.redhat.com/security/cve/{cve}",
+                    fail_condition=(
+                        "If Red Hat lists your product/version as affected, "
+                        "this may not be a false positive."
+                    ),
+                    context=(
+                        "Red Hat's CVE page provides the definitive affected-product "
+                        "list. Check whether your specific product and version appear."
+                    ),
+                ))
+
+        # -----------------------------------------------------------
+        # 3. Steps for not-applicable verdicts (non-RH software)
+        # -----------------------------------------------------------
+        if verdict == Verdict.NOT_APPLICABLE:
+            steps.append(ValidationStep(
+                title="Confirm this is not Red Hat software",
+                command=(
+                    f"rpm -qi {pkg} 2>/dev/null | grep -E 'Vendor|Packager|Signature'"
+                    if pkg else None
+                ),
+                expected=(
+                    "Vendor is NOT 'Red Hat, Inc.' — confirming this is third-party "
+                    "software and Red Hat VEX data does not apply."
+                ),
+                fail_condition=(
+                    "Vendor IS 'Red Hat, Inc.' — the software is from Red Hat and "
+                    "should be re-evaluated. The low source-probability score may "
+                    "have been a false signal from the registry/image detection."
+                ),
+                context=(
+                    f"RH source probability is only {rh_probability:.0%}. If the software "
+                    "is actually from Red Hat, report this as a detection issue."
+                ),
+            ))
+            # Check upstream advisory
+            steps.append(ValidationStep(
+                title="Check if the upstream project has issued a fix",
+                command=None,
+                expected=(
+                    f"Search the upstream project's security advisories for {cve}. "
+                    "If a fix is available, update the package through its native "
+                    "package manager (pip, npm, etc.)."
+                ),
+                fail_condition="N/A",
+                context=(
+                    "Since this does not appear to be Red Hat software, remediation "
+                    "should follow the upstream project's guidance, not Red Hat's."
+                ),
+            ))
+
+        # -----------------------------------------------------------
+        # 4. Steps for upstream (non-RPM) packages
+        # -----------------------------------------------------------
+        has_upstream_flag = any("[UPSTREAM]" in f for f in flags)
+        if has_upstream_flag and pkg:
+            steps.append(ValidationStep(
+                title="Verify this is a non-RPM (upstream) package",
+                command=f"rpm -q {pkg}",
+                expected=(
+                    "'package is not installed' — confirms it is not an RPM, "
+                    "so Red Hat security advisories (RHSAs) do not apply."
+                ),
+                fail_condition=(
+                    "Package IS installed as an RPM — the [UPSTREAM] flag may be "
+                    "incorrect and RHSA remediation could apply."
+                ),
+                context=(
+                    "Upstream packages (pip, npm, gem, etc.) use different versioning "
+                    "than Red Hat RPMs. RHSA fixes address the Red Hat-packaged "
+                    "version, not the upstream release."
+                ),
+            ))
+
+        # -----------------------------------------------------------
+        # 5. Steps when no VEX data was found
+        # -----------------------------------------------------------
+        has_no_vex_flag = any("[!] No RH VEX data found" in f for f in flags)
+        if has_no_vex_flag:
+            steps.append(ValidationStep(
+                title="Manually check Red Hat's CVE database",
+                command=f"curl -s https://access.redhat.com/hydra/rest/securitydata/cve/{cve}.json | python3 -m json.tool | head -20",
+                expected=(
+                    "JSON response with threat_severity, public_date, and affected_release "
+                    "fields — confirms Red Hat has tracked this CVE."
+                ),
+                fail_condition=(
+                    "404 or empty response — Red Hat may not have published data for "
+                    "this CVE yet. It may be too new, or not applicable to RH products."
+                ),
+                context=(
+                    "The VEX document was not found, but the older Security Data API "
+                    "may still have information for this CVE."
+                ),
+            ))
+
+        # -----------------------------------------------------------
+        # 6. Steps for true-positive misrated verdicts
+        # -----------------------------------------------------------
+        if verdict == Verdict.TRUE_POSITIVE_MISRATED and vex_data:
+            steps.append(ValidationStep(
+                title="Verify Red Hat's severity for your specific product",
+                command=None,
+                expected=(
+                    f"Review https://access.redhat.com/security/cve/{cve} and check "
+                    "the per-product severity table. Red Hat may rate severity "
+                    "differently per product depending on exposure."
+                ),
+                fail_condition=(
+                    "If Red Hat's per-product severity matches your scanner, the "
+                    "mismatch may be in the global vs. per-product rating."
+                ),
+                context=(
+                    "Red Hat assigns severity independently from CVSS scores and may "
+                    "differ from the scanner's rating. The per-product table on the "
+                    "CVE page is the authoritative source."
+                ),
+            ))
+            if remediation and remediation.rhsa_id:
+                steps.append(ValidationStep(
+                    title="Check if a fix is available at the correct severity",
+                    command=None,
+                    expected=(
+                        f"Review {remediation.rhsa_url or 'the RHSA'} "
+                        f"({remediation.rhsa_id}) for the actual severity and "
+                        "affected products. Prioritize remediation based on "
+                        "Red Hat's rating, not the scanner's."
+                    ),
+                    fail_condition="N/A",
+                    context=(
+                        "When severities disagree, use Red Hat's assessment for "
+                        "Red Hat software — they evaluate exploitability in the "
+                        "context of their specific builds and configurations."
+                    ),
+                ))
+
+        # -----------------------------------------------------------
+        # 7. Common step: check remediation availability
+        # -----------------------------------------------------------
+        if verdict in (Verdict.TRUE_POSITIVE, Verdict.TRUE_POSITIVE_MISRATED):
+            if remediation and remediation.rhsa_id and pkg:
+                steps.append(ValidationStep(
+                    title="Apply the available fix",
+                    command=f"dnf update --advisory {remediation.rhsa_id} {pkg}",
+                    expected=(
+                        f"Package {pkg} is updated to the fixed version. "
+                        "Verify with: rpm -q " + pkg
+                    ),
+                    fail_condition=(
+                        "Update not available — check that the system is registered "
+                        "and entitled to the correct Red Hat repositories."
+                    ),
+                    context=(
+                        f"Red Hat has published {remediation.rhsa_id} with a fix. "
+                        "Applying it resolves this finding."
+                    ),
+                ))
+            elif not remediation and vex_data:
+                steps.append(ValidationStep(
+                    title="Check for available fixes",
+                    command=None,
+                    expected=(
+                        f"Visit https://access.redhat.com/security/cve/{cve} and "
+                        "check the 'Affected Packages and Issued Red Hat Security "
+                        "Errata' section for your product."
+                    ),
+                    fail_condition=(
+                        "If no errata is listed for your product, the fix may not "
+                        "yet be available or the product may be in a 'will not fix' state."
+                    ),
+                    context=(
+                        "No matching RHSA was found for your specific package/version "
+                        "combination, but one may exist for a different product stream."
+                    ),
+                ))
+
+        return steps
+
     def _calculate_summary(
         self,
         results: list[AnalysisResult],

--- a/rh_cve_checker/core/models.py
+++ b/rh_cve_checker/core/models.py
@@ -904,17 +904,27 @@ class RedHatVEXData(BaseModel):
         return best_match
 
 
+class ValidationStep(BaseModel):
+    """A prescriptive step the user can take to confirm a finding's verdict."""
+
+    title: str = Field(..., description="Short title for the validation step")
+    command: str | None = Field(None, description="Exact command to run")
+    expected: str | None = Field(None, description="Expected output that confirms the verdict")
+    fail_condition: str | None = Field(None, description="Output that would contradict the verdict")
+    context: str | None = Field(None, description="Explanation of why this step matters")
+
+
 class AnalysisResult(BaseModel):
     """Result of analyzing a single scanner finding against VEX data."""
-    
+
     finding: ScannerFinding = Field(..., description="Original scanner finding")
     vex_data: RedHatVEXData | None = Field(None, description="Red Hat VEX data if found")
-    
+
     # Comparison results
     severity_match: bool = Field(True, description="Whether severities match")
     severity_delta: int = Field(0, description="Severity level difference (positive = scanner higher)")
     cvss_delta: float | None = Field(None, description="CVSS score difference")
-    
+
     # Classification
     is_false_positive: bool = Field(False, description="Determined to be false positive")
     is_will_not_fix: bool = Field(
@@ -925,13 +935,19 @@ class AnalysisResult(BaseModel):
         0.5, ge=0.0, le=1.0, description="Probability source is Red Hat"
     )
     verdict: Verdict = Field(Verdict.INCONCLUSIVE, description="Analysis verdict")
-    
+
     # Issues found
     flags: list[str] = Field(default_factory=list, description="Issues to highlight")
     notes: str | None = Field(None, description="Additional notes")
-    
+
     # Remediation
     remediation: Remediation | None = Field(None, description="Available remediation/fix")
+
+    # Validation steps for confirming the verdict
+    validation_steps: list[ValidationStep] = Field(
+        default_factory=list,
+        description="Prescriptive steps to confirm or refute this verdict on your system",
+    )
     
     # OCP release info (populated when analyzing OCP release images)
     ocp_component: str | None = Field(None, description="OCP component name")

--- a/rh_cve_checker/core/models.py
+++ b/rh_cve_checker/core/models.py
@@ -370,7 +370,8 @@ class RedHatVEXData(BaseModel):
     updated_date: datetime | None = Field(None, description="Last update date")
     state: str | None = Field(None, description="Vulnerability state (e.g., 'fixed', 'affected')")
     raw_vex: dict[str, Any] = Field(default_factory=dict, description="Raw VEX document")
-    
+    retrieved_at: datetime | None = Field(None, description="When VEX data was fetched")
+
     @property
     def normalized_severity(self) -> Severity:
         """Get normalized global severity enum (Red Hat terminology)."""
@@ -912,6 +913,8 @@ class ValidationStep(BaseModel):
     expected: str | None = Field(None, description="Expected output that confirms the verdict")
     fail_condition: str | None = Field(None, description="Output that would contradict the verdict")
     context: str | None = Field(None, description="Explanation of why this step matters")
+    reference: str | None = Field(None, description="URL to source document (VEX, CVE page, RHSA)")
+    observed_output: str | None = Field(None, description="Actual command output recorded during validation")
 
 
 class AnalysisResult(BaseModel):
@@ -948,7 +951,11 @@ class AnalysisResult(BaseModel):
         default_factory=list,
         description="Prescriptive steps to confirm or refute this verdict on your system",
     )
-    
+
+    # VEX provenance
+    vex_document_url: str | None = Field(None, description="URL of the VEX document consulted")
+    vex_retrieved_at: datetime | None = Field(None, description="Timestamp when VEX data was fetched")
+
     # OCP release info (populated when analyzing OCP release images)
     ocp_component: str | None = Field(None, description="OCP component name")
     ocp_version: str | None = Field(None, description="OCP version (e.g., 4.16.0)")

--- a/rh_cve_checker/core/validation_report.py
+++ b/rh_cve_checker/core/validation_report.py
@@ -1,0 +1,180 @@
+"""Generate a standalone Markdown validation report for audit evidence."""
+
+from datetime import datetime
+
+from .models import AnalysisReport, AnalysisResult, Verdict
+
+
+def generate_validation_report(report: AnalysisReport) -> str:
+    """
+    Produce a standalone Markdown document suitable for audit evidence.
+
+    The document contains:
+    - Report metadata table
+    - VEX data provenance table
+    - Validation checklists grouped by verdict
+    - Evidence capture instructions
+    - Attestation template
+    """
+    lines: list[str] = []
+
+    summary = report.summary
+    score = summary.validation_score
+    now = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+    # ── Title ────────────────────────────────────────────────────
+    lines.append("# CVE Validation Report")
+    lines.append("")
+
+    # ── Report Metadata ──────────────────────────────────────────
+    lines.append("## Report Metadata")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("|-------|-------|")
+    lines.append(f"| Report generated | {now} |")
+    lines.append("| Tool | rh-cve-checker 0.1.0 |")
+    lines.append(f"| Scanner | {summary.scanner_name or 'Auto-detected'} |")
+    lines.append(f"| Source files | {', '.join(summary.source_files) if summary.source_files else 'N/A'} |")
+    lines.append(f"| Total findings | {summary.total_findings} |")
+    lines.append(f"| Validation score | {score:.1f} / 100 |")
+    lines.append("")
+
+    # ── VEX Data Provenance ──────────────────────────────────────
+    # Collect unique (vex_document_url, vex_retrieved_at) pairs
+    provenance: dict[str, str] = {}
+    for result in report.findings:
+        url = result.vex_document_url
+        ts = result.vex_retrieved_at
+        if url and url not in provenance:
+            provenance[url] = ts.strftime("%Y-%m-%d %H:%M UTC") if ts else "N/A"
+
+    if provenance:
+        lines.append("## VEX Data Provenance")
+        lines.append("")
+        lines.append("| VEX Document URL | Retrieved At |")
+        lines.append("|------------------|-------------|")
+        for url, ts in provenance.items():
+            lines.append(f"| {url} | {ts} |")
+        lines.append("")
+
+    # ── Helper: render a checklist for a list of results ─────────
+    def _render_checklist(results: list[AnalysisResult]) -> None:
+        # Deduplicate by (CVE, package, verdict)
+        seen: set[tuple[str, str, str]] = set()
+        for result in results:
+            key = (
+                result.finding.cve_id,
+                result.finding.package_name or "",
+                result.verdict.value,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+
+            cve = result.finding.cve_id
+            pkg = result.finding.package_name or "N/A"
+            ver = result.finding.package_version or "N/A"
+            target = (
+                result.finding.image_name
+                or result.finding.host
+                or "N/A"
+            )
+
+            lines.append(f"### {cve} — {pkg}")
+            lines.append("")
+            lines.append(f"- **Package version:** `{ver}`")
+            lines.append(f"- **Target:** `{target}`")
+            lines.append(f"- **Verdict:** {result.verdict.value.replace('_', ' ').title()}")
+            if result.flags:
+                lines.append(f"- **Flags:** {'; '.join(result.flags)}")
+            if result.vex_document_url:
+                lines.append(f"- **VEX document:** {result.vex_document_url}")
+            lines.append("")
+
+            if result.validation_steps:
+                for i, step in enumerate(result.validation_steps, 1):
+                    lines.append(f"- [ ] **Step {i}: {step.title}**")
+                    if step.command:
+                        lines.append(f"  ```")
+                        lines.append(f"  {step.command}")
+                        lines.append(f"  ```")
+                    if step.expected:
+                        lines.append(f"  **Expected:** {step.expected}")
+                    if step.fail_condition and step.fail_condition != "N/A":
+                        lines.append(f"  **Fail if:** {step.fail_condition}")
+                    if step.reference:
+                        lines.append(f"  **Reference:** {step.reference}")
+                    lines.append("")
+            else:
+                lines.append("_No validation steps generated for this finding._")
+                lines.append("")
+
+    # ── Validation Checklists by Verdict ─────────────────────────
+    lines.append("## Validation Checklists")
+    lines.append("")
+
+    verdict_groups = [
+        ("False Positives", Verdict.FALSE_POSITIVE),
+        ("Likely False Positives", Verdict.LIKELY_FALSE_POSITIVE),
+        ("True Positives", Verdict.TRUE_POSITIVE),
+        ("True Positives — Misrated", Verdict.TRUE_POSITIVE_MISRATED),
+        ("Inconclusive", Verdict.INCONCLUSIVE),
+        ("Not Applicable", Verdict.NOT_APPLICABLE),
+    ]
+
+    for label, verdict_value in verdict_groups:
+        matching = [r for r in report.findings if r.verdict == verdict_value]
+        if not matching:
+            continue
+        lines.append(f"### {label} ({len(matching)})")
+        lines.append("")
+        _render_checklist(matching)
+
+    # Will Not Fix as a sub-section (these overlap with TP but have
+    # the is_will_not_fix flag set)
+    wnf = [r for r in report.findings if r.is_will_not_fix]
+    if wnf:
+        lines.append(f"### Will Not Fix ({len(wnf)})")
+        lines.append("")
+        _render_checklist(wnf)
+
+    # ── Evidence Capture Instructions ────────────────────────────
+    lines.append("## Evidence Capture Instructions")
+    lines.append("")
+    lines.append("When executing the validation commands above, capture output as evidence:")
+    lines.append("")
+    lines.append("### Pipe to a file")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("rpm -q <package> 2>&1 | tee evidence/<CVE>-rpm-check.txt")
+    lines.append("```")
+    lines.append("")
+    lines.append("### Record a terminal session")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("script -q evidence/validation-session.log")
+    lines.append("# ... run validation commands ...")
+    lines.append("exit  # stops recording")
+    lines.append("```")
+    lines.append("")
+    lines.append("### Timestamp evidence files")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("sha256sum evidence/*.txt > evidence/checksums.sha256")
+    lines.append("date -u >> evidence/checksums.sha256")
+    lines.append("```")
+    lines.append("")
+
+    # ── Attestation Template ─────────────────────────────────────
+    lines.append("## Attestation")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("|-------|-------|")
+    lines.append("| Reviewer name | |")
+    lines.append("| Review date | |")
+    lines.append(f"| Findings reviewed | {summary.total_findings} |")
+    lines.append("| Exceptions noted | |")
+    lines.append("| Signature | |")
+    lines.append("")
+
+    return "\n".join(lines)

--- a/rh_cve_checker/vex/client.py
+++ b/rh_cve_checker/vex/client.py
@@ -595,13 +595,17 @@ class VEXClient:
                 # Check if this is a pre-parsed result (has _parsed marker)
                 if cached.get("_parsed"):
                     try:
-                        return RedHatVEXData(**cached["data"])
+                        result = RedHatVEXData(**cached["data"])
+                        if not result.retrieved_at:
+                            result.retrieved_at = datetime.utcnow()
+                        return result
                     except Exception as e:
                         logger.warning(f"Error deserializing cached VEX data for {cve_id}: {e}")
                 else:
                     # Legacy raw format - parse and re-cache
                     try:
                         parsed = self._parse_vex_document(cve_id, cached)
+                        parsed.retrieved_at = datetime.utcnow()
                         # Re-cache as parsed
                         self._cache.set(cve_id, {"_parsed": True, "data": parsed.model_dump(mode="json")})
                         return parsed
@@ -626,10 +630,11 @@ class VEXClient:
             
             # Parse first
             parsed = self._parse_vex_document(cve_id, raw_vex)
-            
+            parsed.retrieved_at = datetime.utcnow()
+
             # Cache the parsed data (faster to deserialize than to re-parse)
             self._cache.set(cve_id, {"_parsed": True, "data": parsed.model_dump(mode="json")})
-            
+
             return parsed
             
         except httpx.HTTPStatusError as e:
@@ -683,7 +688,10 @@ class VEXClient:
                     elif cached.get("_parsed"):
                         # Fast path: deserialize pre-parsed data
                         try:
-                            results[cve_id] = RedHatVEXData(**cached["data"])
+                            result = RedHatVEXData(**cached["data"])
+                            if not result.retrieved_at:
+                                result.retrieved_at = datetime.utcnow()
+                            results[cve_id] = result
                         except Exception as e:
                             logger.warning(f"Error deserializing cached VEX for {cve_id}: {e}")
                             to_fetch.append(cve_id)
@@ -691,6 +699,7 @@ class VEXClient:
                         # Legacy raw format - need to parse (slow)
                         try:
                             parsed = self._parse_vex_document(cve_id, cached)
+                            parsed.retrieved_at = datetime.utcnow()
                             results[cve_id] = parsed
                             # Re-cache as parsed for future speed
                             self._cache.set(cve_id, {"_parsed": True, "data": parsed.model_dump(mode="json")})
@@ -722,6 +731,7 @@ class VEXClient:
                         
                         # Parse and cache parsed result (faster for future lookups)
                         parsed = self._parse_vex_document(cve_id, raw_vex)
+                        parsed.retrieved_at = datetime.utcnow()
                         self._cache.set(cve_id, {"_parsed": True, "data": parsed.model_dump(mode="json")})
                         return cve_id, parsed
                         

--- a/rh_cve_checker/web/app.py
+++ b/rh_cve_checker/web/app.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
@@ -232,6 +232,36 @@ async def get_report(report_id: str) -> dict[str, Any]:
         raise HTTPException(status_code=404, detail="Report not found")
     
     return reports_store[report_id]
+
+
+@app.get("/api/report/{report_id}/validation-report")
+async def get_validation_report(report_id: str) -> Response:
+    """
+    Generate and download a Markdown validation report for a stored analysis.
+
+    Returns the report as ``text/markdown`` with a Content-Disposition header
+    so the browser downloads it as a ``.md`` file.
+    """
+    if report_id not in reports_store:
+        raise HTTPException(status_code=404, detail="Report not found")
+
+    report_dict = reports_store[report_id]
+
+    # Re-hydrate into an AnalysisReport so the generator can work with
+    # the Pydantic models it expects.
+    from ..core.models import AnalysisReport as ARModel
+    from ..core.validation_report import generate_validation_report
+
+    report = ARModel(**report_dict)
+    md_content = generate_validation_report(report)
+
+    return Response(
+        content=md_content,
+        media_type="text/markdown",
+        headers={
+            "Content-Disposition": f'attachment; filename="validation-report-{report_id}.md"',
+        },
+    )
 
 
 def _strip_raw_data(finding: dict) -> dict:

--- a/rh_cve_checker/web/templates/report.html
+++ b/rh_cve_checker/web/templates/report.html
@@ -1104,7 +1104,40 @@ function renderFindingRow(finding) {
     } else {
         componentHtml = '<span class="text-muted">-</span>';
     }
-    
+
+    // Validation steps — deduplicate by (CVE, package, verdict)
+    const validationSteps = finding.validation_steps || [];
+    const pkgName = f.package_name || '';
+    const stepsKey = `${cveId}|${pkgName}|${verdict}`;
+    let stepsToggle = '';
+    let stepsRow = '';
+    if (validationSteps.length > 0 && !window._seenStepsKeys.has(stepsKey)) {
+        window._seenStepsKeys.add(stepsKey);
+        const rowId = `steps-${cveId.replace(/[^a-zA-Z0-9]/g, '-')}-${pkgName.replace(/[^a-zA-Z0-9]/g, '-')}`;
+        stepsToggle = `<button class="btn btn-outline-secondary btn-sm mt-1" onclick="toggleSteps('${rowId}')" title="Show validation steps"><i class="bi bi-list-check"></i> ${validationSteps.length} step${validationSteps.length > 1 ? 's' : ''}</button>`;
+
+        let stepsHtml = '<ol class="mb-0 ps-3">';
+        validationSteps.forEach(step => {
+            stepsHtml += `<li class="mb-2"><strong>${escapeHtml(step.title)}</strong>`;
+            if (step.command) {
+                stepsHtml += `<br><code class="text-success">$ ${escapeHtml(step.command)}</code>`;
+            }
+            if (step.expected) {
+                stepsHtml += `<br><small class="text-muted"><strong>Expected:</strong> ${escapeHtml(step.expected)}</small>`;
+            }
+            if (step.fail_condition) {
+                stepsHtml += `<br><small class="text-danger"><strong>Fail if:</strong> ${escapeHtml(step.fail_condition)}</small>`;
+            }
+            if (step.context) {
+                stepsHtml += `<br><small class="text-secondary"><strong>Why:</strong> ${escapeHtml(step.context)}</small>`;
+            }
+            stepsHtml += '</li>';
+        });
+        stepsHtml += '</ol>';
+
+        stepsRow = `<tr id="${rowId}" style="display:none;"><td colspan="7" class="bg-light border-start border-4 border-warning ps-3">${stepsHtml}</td></tr>`;
+    }
+
     return `
         <tr>
             <td>
@@ -1112,6 +1145,7 @@ function renderFindingRow(finding) {
                     ${idDisplay}
                     <i class="bi bi-box-arrow-up-right ms-1 small"></i>
                 </a>
+                ${stepsToggle}
             </td>
             <td>${packageHtml}</td>
             <td>${componentHtml}</td>
@@ -1127,6 +1161,7 @@ function renderFindingRow(finding) {
             <td>${flagsHtml}</td>
         </tr>
         ${expandableRow}
+        ${stepsRow}
     `;
 }
 
@@ -1141,12 +1176,12 @@ function escapeHtml(text) {
 function toggleComponentRow(rowId) {
     const row = document.getElementById(rowId + '-row');
     const btn = document.getElementById(rowId + '-btn');
-    
+
     if (row && btn) {
         const isHidden = row.style.display === 'none';
         row.style.display = isHidden ? 'table-row' : 'none';
         btn.setAttribute('aria-expanded', isHidden ? 'true' : 'false');
-        
+
         // Update icon
         const icon = btn.querySelector('.expand-icon');
         if (icon) {
@@ -1182,11 +1217,24 @@ function normalizeSeverity(severity) {
     return severity.charAt(0).toUpperCase() + severity.slice(1).toLowerCase();
 }
 
+// Toggle validation steps visibility
+function toggleSteps(rowId) {
+    const row = document.getElementById(rowId);
+    if (row) {
+        row.style.display = row.style.display === 'none' ? '' : 'none';
+    }
+}
+
+// Track which validation step groups have already been rendered
+window._seenStepsKeys = new Set();
+
 // Load findings from API
 async function loadFindings() {
+    // Reset dedup tracker on each load/filter/page change
+    window._seenStepsKeys = new Set();
     const offset = (currentPage - 1) * pageSize;
     const tbody = document.getElementById('findingsBody');
-    
+
     try {
         tbody.innerHTML = '<tr><td colspan="9" class="text-center py-4"><div class="spinner-border spinner-border-sm" role="status"></div> Loading...</td></tr>';
         

--- a/rh_cve_checker/web/templates/report.html
+++ b/rh_cve_checker/web/templates/report.html
@@ -44,8 +44,11 @@
         <a href="/" class="btn btn-outline-secondary me-2">
             <i class="bi bi-arrow-left me-1"></i> New Analysis
         </a>
-        <button class="btn btn-outline-primary" onclick="downloadReport()">
+        <button class="btn btn-outline-primary me-2" onclick="downloadReport()">
             <i class="bi bi-download me-1"></i> Download JSON
+        </button>
+        <button class="btn btn-outline-success" onclick="downloadValidationReport()">
+            <i class="bi bi-file-earmark-text me-1"></i> Download Validation Report
         </button>
     </div>
 </div>
@@ -774,6 +777,24 @@ async function downloadReport() {
     }
 }
 
+// Download validation report as Markdown
+async function downloadValidationReport() {
+    try {
+        const response = await fetch(`/api/report/${reportId}/validation-report`);
+        if (!response.ok) throw new Error('Failed to generate validation report');
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `validation-report-${reportId}.md`;
+        a.click();
+        URL.revokeObjectURL(url);
+    } catch (error) {
+        console.error('Download failed:', error);
+        alert('Failed to download validation report');
+    }
+}
+
 // Severity chart
 const ctx = document.getElementById('severityChart').getContext('2d');
 const scannerSev = reportSummary.by_scanner_severity;
@@ -1130,6 +1151,9 @@ function renderFindingRow(finding) {
             }
             if (step.context) {
                 stepsHtml += `<br><small class="text-secondary"><strong>Why:</strong> ${escapeHtml(step.context)}</small>`;
+            }
+            if (step.reference) {
+                stepsHtml += `<br><small class="text-info"><strong>Ref:</strong> <a href="${escapeHtml(step.reference)}" target="_blank" class="text-info">${escapeHtml(step.reference)} <i class="bi bi-box-arrow-up-right"></i></a></small>`;
             }
             stepsHtml += '</li>';
         });


### PR DESCRIPTION
## Summary

- When the tool classifies a finding as a false positive, likely false positive, not applicable, or misrated, it now generates specific validation steps the user can run on their system to confirm the verdict
- Each step includes the exact command, expected output, fail condition, and contextual explanation — modeled after the SRE Validation Checklist pattern
- Steps are context-specific based on registry, image name, and package characteristics (OpenShift images, quay.io, Docker Hub, gcr.io, host-based RHEL scans, etc.)
- Validation steps are deduplicated by CVE/package/verdict so repeated occurrences across images or hosts are shown once with an occurrence count
- Rendered in CLI output after the findings table and as expandable rows in the web UI

## Validation step types

| Context | Steps Generated |
|---|---|
| FP: PATCHED | `rpm -q` version check, `rpm -q --changelog` RHSA verification |
| FP: NOT AFFECTED | Image label verification against VEX product entry |
| OpenShift images on quay.io | `oc adm release info` payload check, `oc image info` build labels |
| Generic quay.io images | `podman inspect` for Red Hat vendor labels, RPM GPG signature |
| Known non-RH registries (gcr/ghcr/mcr) | Direct upstream remediation guidance |
| Docker Hub | `podman inspect` vendor label check |
| Host-based scans | `rpm -qi` vendor/signature check |
| True positive misrated | Per-product severity table on RH CVE page |
| True positive with fix | `dnf update --advisory` command |
| No VEX data | `curl` to Security Data API fallback |

## Test plan

- [ ] Run against a Nessus RHEL host scan CSV — verify `rpm -q`, `dnf update --advisory` commands render correctly
- [ ] Run against an RHACS/Prisma container scan — verify quay.io and OpenShift-specific steps appear
- [ ] Run with `--filter likely_fp` — verify deduplication shows occurrence counts
- [ ] Run with `--filter false_positive` — verify FP PATCHED steps with version and RHSA changelog checks
- [ ] Run with `--json` output — verify `validation_steps` array is present in JSON
- [ ] Test web UI — verify expandable step rows appear on findings with steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)